### PR TITLE
Update .editorconfig

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
 ###############################
-# Eternet.EditorConfig v1.0.2 #
+# Eternet.EditorConfig v1.0.3 #
 ###############################
 root = true
 
@@ -162,6 +162,10 @@ dotnet_diagnostic.CA1822.severity = none
 # Warnings on missing forward pass of cancellation tokens
 dotnet_diagnostic.CA2016.severity = warning
 dotnet_diagnostic.CA1068.severity = warning
+
+# Warnings on properties with bad case
+dotnet_diagnostic.CA1707.severity = warning
+dotnet_diagnostic.CA1006.severity = warning
 
 # xUnit
 dotnet_diagnostic.xUnit1042.severity = warning


### PR DESCRIPTION
Sumo reglas para marcar como warning el naming de las propiedades. 

Pasamos de:
![image](https://github.com/user-attachments/assets/93504bd2-b9ee-4b62-9031-aa01760238e4)

A:
![image](https://github.com/user-attachments/assets/8c964ecf-28c8-473f-b9b3-40754cd8fea2)

Sumo solo la config para marcar el warning en base a la config existente. Las reglas de cuando usar un case u otro ya estaban definidas y de ser necesario las podemos debatir en otro momento.

Seria interesante que usemos siempre propiedades `{get; set; }`, ya que si se usa campos de clase el warning y la reglas no hacen efecto. Segun ChatGPT no existe reglas para campos de clase. Las propiedades tienen la ventaja de las referencias.

A que me refiero con campo de clase (sin el `{get; set; }`):
![image](https://github.com/user-attachments/assets/91bd1551-598e-4d72-8e20-5a4265567c42)

