### PR TITLE
Rollback last .editorconfig changes

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
 ###############################
-# Eternet.EditorConfig v1.0.3 #
+# Eternet.EditorConfig v1.0.4 #
 ###############################
 root = true
 
@@ -162,10 +162,6 @@ dotnet_diagnostic.CA1822.severity = none
 # Warnings on missing forward pass of cancellation tokens
 dotnet_diagnostic.CA2016.severity = warning
 dotnet_diagnostic.CA1068.severity = warning
-
-# Warnings on properties with bad case
-dotnet_diagnostic.CA1707.severity = warning
-dotnet_diagnostic.CA1006.severity = warning
 
 # xUnit
 dotnet_diagnostic.xUnit1042.severity = warning


### PR DESCRIPTION
Vuelvo para atras los cambios de https://github.com/Eternet/github/pull/3, ya que como se comenta genera un warning en los nombres de metodos de tests que incluyen guion bajo