### PR TITLE
Added test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+on:
+    workflow_call:
+        inputs:
+            project-paths:
+                description: "Array of paths to individual project files to test"
+                required: true
+                type: list
+
+jobs:
+    test:
+        runs-on: self-hosted
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.pull_request.head.sha }}
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: "8.0.204"
+
+            - name: Run tests for each project
+              shell: pwsh
+              run: |
+                  $projectPaths = @(${{ inputs.project-paths }})
+                  foreach ($project in $projectPaths) {
+                    dotnet test $project -c Release --verbosity=normal
+                  }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,30 +1,30 @@
 name: Test
 on:
-    workflow_call:
-        inputs:
-            project-paths:
-                description: "Array of paths to individual project files to test"
-                required: true
-                type: list
+  workflow_call:
+    inputs:
+      paths:
+        description: "Array of paths to .sln or .csproj files"
+        required: true
+        type: list
 
 jobs:
-    test:
-        runs-on: self-hosted
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.pull_request.head.sha }}
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.pull_request.head.sha }}
 
-            - name: Setup .NET
-              uses: actions/setup-dotnet@v4
-              with:
-                  dotnet-version: "8.0.204"
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.204"
 
-            - name: Run tests for each project
-              shell: pwsh
-              run: |
-                  $projectPaths = @(${{ inputs.project-paths }})
-                  foreach ($project in $projectPaths) {
-                    dotnet test $project -c Release --verbosity=normal
-                  }
+      - name: Run tests for each path
+        shell: pwsh
+        run: |
+          $paths = @(${{ inputs.paths }})
+          foreach ($path in $paths) {
+            dotnet test $path -c Release --verbosity=normal
+          }


### PR DESCRIPTION
Sumo GA reutilizable para correr tests. Recibe como parametro un array de string que representan los proyectos a correr, por ejemplo se reutilizaria como una sintaxis similar a:

```bash
jobs:
  call-test-action:
    steps:
    - name: Call reusable test action
      uses: Eternet/github/.github/workflows/test.yml@main
      with:
        project-paths: |
          [
            'src/Project1/Project1.csproj',
            'src/Project2/Project2.csproj',
            'src/Project3/Project3.csproj'
          ]
```
