### PR TITLE
Update .editorconfig for improved C# formatting and naming conventions

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -8,8 +8,10 @@ root = true
 ###############################
 [*]
 charset = utf-8
-indent_size = 4
 end_of_line = crlf
+indent_style = tab
+indent_size = 4
+tab_width = 4
 
 ###############################
 # .NET Coding Conventions     #
@@ -96,7 +98,8 @@ csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 # Namespaces
-csharp_style_namespace_declarations = file_scoped:warning
+dotnet_diagnostic.IDE0161.severity = warning
+csharp_style_namespace_declarations = file_scoped
 ###############################
 # C# Formatting Rules         #
 ###############################
@@ -165,3 +168,16 @@ dotnet_diagnostic.CA1068.severity = warning
 
 # xUnit
 dotnet_diagnostic.xUnit1042.severity = warning
+csharp_indent_labels = flush_left
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = file_scoped:silent
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+
+# IDE0005: Using directive is unnecessary
+dotnet_diagnostic.IDE0005.severity = warning


### PR DESCRIPTION
Sumo las mejores que fui implementando en https://github.com/Eternet/Eternet.Promos/commits/main/.editorconfig

Inicialmente, sumé el .editorconfig tal cual como está acá. Luego, me fui encontrando con varias cositas que fui mejorando de a una en esos commits, explicadas por títulos.

Primero, no estaba tabeando correctamente.

Segundo, dotnet format no aplicaba el namespace file scoped (me encontré con este bug https://github.com/dotnet/roslyn/issues/60546)

Tercero, al abrir el archivo .editorconfig desde VS se agregaban unas líneas obligatorias. Esto siempre provocaba cambios al querer visualizarlo. Lo dejé unificado con lo que VS espera para evitar este comportamiento.

Cuarto, a partir de ahora, correr dotnet format elimina automáticamente los usings innecesarios.

Es importante que dotnet format se comporte como esperamos, porque esto nos asegura respetar ciertas reglas en todos lados por igual, incluso en CI/CD. Si dependemos del Code Cleanup de VS, esto está atado a que puedas correr VS (windows) y estas reglas no quedan unificadas y determinísticas para todos.

Pasó más de un mes desde que hice esas mejoras en ese repo, postergué varias veces centralizar los cambios acá. Quizás algunas explicaciones están un poco incompletas (por ej. ese issue de roslyn me lo anoté porque era importante mencionarlo, pero no lo tengo muy fresco ahora). Cualquier cosa si algún punto requiere debate, vamos detallando.