### PR TITLE
Update .editorconfig to version 1.0.5 and change indent style to spaces

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
 ###############################
-# Eternet.EditorConfig v1.0.4 #
+# Eternet.EditorConfig v1.0.5 #
 ###############################
 root = true
 
@@ -9,9 +9,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = crlf
-indent_style = tab
+indent_style = space
 indent_size = 4
-tab_width = 4
 
 ###############################
 # .NET Coding Conventions     #


### PR DESCRIPTION
Hago el rollback del indent_style modificado en https://github.com/Eternet/github/pull/8 (antes no estaba pero por defecto toma space) en base a lo detectado en https://github.com/Eternet/Eternet.Api/pull/984 y segun lo hablado de seguir las convenciones de repos como https://github.com/dotnet/aspnetcore/blob/main/.editorconfig o https://github.com/dotnet/aspire/blob/main/.editorconfig.
