### PR TITLE
Improve editorconfig charset

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
 ###############################
-# Eternet.EditorConfig v1.0.5 #
+# Eternet.EditorConfig v1.0.6 #
 ###############################
 root = true
 
@@ -7,7 +7,7 @@ root = true
 # Global Conventions          #
 ###############################
 [*]
-charset = utf-8
+charset = utf-8-bom
 end_of_line = crlf
 indent_style = space
 indent_size = 4

--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
 ###############################
-# Eternet.EditorConfig v1.0.4 #
+# Eternet.EditorConfig v1.0.5 #
 ###############################
 root = true
 
@@ -9,9 +9,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = crlf
-indent_style = tab
+indent_style = space
 indent_size = 4
-tab_width = 4
 
 ###############################
 # .NET Coding Conventions     #


### PR DESCRIPTION
Al tener `charset = utf-8` y aplicar dotnet format desde la terminal, el git changes de visual studio muestra:
