### PR TITLE
Update workflow to run formatting checks before tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,25 @@ jobs:
                   $paths = ConvertFrom-Json -InputObject '${{ inputs.paths }}'
                   foreach ($path in $paths) {
                     dotnet format $path --verify-no-changes
-                    dotnet test $path -c Release --verbosity=minimal
+                    dotnet test $path -c Release --verbosity=minimal --results-directory TestResults -- --report-trx --report-trx-filename AllTests.trx
                   }
+
+            - name: Publish test results
+              uses: Eternet/publish-unit-test-result-action/windows@v2
+              if: always()
+              with:
+                  files: "**/TestResults/**/*.trx"
+                  check_name: Tests
+                  job_summary: true
+
+            - name: Debug TestResults
+              if: always()
+              run: dir **\TestResults\*
+
+            - name: Upload TestResults artifact
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: TestResults
+                  path: "**/TestResults/**/*.trx"
+                  retention-days: 7


### PR DESCRIPTION
Actualizo la GA base de tests para ejecutar el dotnet format. Se usa el mismo parametro paths que se tenia, donde se puede recibir un .sln o varios .csproj

Tambien sumo los pasos (extraidos desde https://github.com/Eternet/Eternet.Api/blob/main/.github/workflows/run-tests.yml) para el comentario del informe del resultado de los tests