### PR TITLE
Add format workflow and update test workflow to remove formatting step

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,15 @@
+name: Format
+on:
+    workflow_call:
+        inputs:
+            path:
+                description: "Path to .sln file"
+                required: true
+                type: string
+
+jobs:
+    format:
+        runs-on: self-hosted
+        steps:
+            - name: Execute dotnet format
+              run: dotnet format ${{ inputs.path }} --verify-no-changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,12 @@ jobs:
               run: |
                   dotnet new globaljson --sdk-version $env:DOTNET_VERSION
 
-            - name: Run format and tests for each path
+            - name: Run tests for each path
               shell: pwsh
               run: |
                   # Parse the input string to a JSON array
                   $paths = ConvertFrom-Json -InputObject '${{ inputs.paths }}'
                   foreach ($path in $paths) {
-                    dotnet format $path --verify-no-changes
                     dotnet test $path -c Release --verbosity=minimal --results-directory TestResults -- --report-trx --report-trx-filename AllTests.trx
                   }
 


### PR DESCRIPTION
Muevo dotnet format a nueva GA segun lo hablado en https://github.com/Eternet/github/pull/11#issuecomment-3020094871.

Ahora para consumirla, se necesitaria algo como:

```bash
  call-format-action:
    uses: Eternet/github/.github/workflows/format.yml@main
    with:
      path: "src/MyApp.sln"
```
