### PR TITLE
Update .editorconfig to adjust indent sizes for various file types

### DIFF
--- a/files/.editorconfig
+++ b/files/.editorconfig
@@ -1,5 +1,5 @@
-###############################
-# Eternet.EditorConfig v1.0.6 #
+﻿###############################
+# Eternet.EditorConfig v1.0.7 #
 ###############################
 root = true
 
@@ -180,3 +180,21 @@ csharp_style_expression_bodied_accessors = true:silent
 
 # IDE0005: Using directive is unnecessary
 dotnet_diagnostic.IDE0005.severity = warning
+
+###############################
+# Indent size                 #
+###############################
+[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
+indent_size = 2
+
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.{ps1,psm1}]
+indent_size = 4
+
+[*.sh]
+indent_size = 4


### PR DESCRIPTION
Mejoro la configuración de indent_size para diferentes tipos de archivos, ya que anteriormente solo estaba configurado a nivel global con indent_size=4.

Revisé repositorios como:
- https://github.com/dotnet/aspnetcore/blob/main/.editorconfig
- https://github.com/dotnet/aspire/blob/main/.editorconfig
- https://github.com/microsoft/fluentui-blazor/blob/dev/.editorconfig

Todos coinciden en configurar indent_size=2 para determinados tipos de archivo, creo que tiene mucho sentido seguir la misma línea.

En archivos openapi .json solemos tener problemas cuando se publica la especificación en swagger con 2 espacios y luego se guarda con 4 al guardar el archivo con auto format.

En archivos .csproj, por lo que investigué, dotnet format no funciona de manera correcta y lo más estándar o por defecto es guardarlos con 2 espacios.

El cambio surge al intentar forzar el uso de dotnet format como hook de git o en agentes, primero debemos ir puliendo bien el editorconfig para que el format consiga el resultado esperado.

