### PR TITLE
Fix reusable test result publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,25 +33,30 @@ jobs:
                   # Parse the input string to a JSON array
                   $paths = ConvertFrom-Json -InputObject '${{ inputs.paths }}'
                   foreach ($path in $paths) {
-                    dotnet test $path -c Release --verbosity=minimal --results-directory TestResults -- --report-trx --report-trx-filename AllTests.trx
+                    dotnet test $path -c Release --verbosity=minimal --results-directory TestResults --logger trx
                   }
 
             - name: Publish test results
               uses: Eternet/publish-unit-test-result-action/windows@v2
               if: always()
               with:
-                  files: "**/TestResults/**/*.trx"
+                  files: |
+                      **/TestResults/*.trx
+                      **/TestResults/**/*.trx
                   check_name: Tests
                   job_summary: true
 
             - name: Debug TestResults
               if: always()
-              run: dir **\TestResults\*
+              shell: pwsh
+              run: Get-ChildItem -Recurse -Path . -Filter *.trx | Select-Object FullName
 
             - name: Upload TestResults artifact
               uses: actions/upload-artifact@v4
               if: always()
               with:
                   name: TestResults
-                  path: "**/TestResults/**/*.trx"
+                  path: |
+                      **/TestResults/*.trx
+                      **/TestResults/**/*.trx
                   retention-days: 7


### PR DESCRIPTION
## Summary
- Use the VSTest TRX logger when running `dotnet test` from the reusable workflow.
- Publish and upload `.trx` files written directly under `TestResults` as well as nested folders.
- Replace the debug glob with a recursive `.trx` listing.

## Why
`-- --report-trx` is ignored by projects that still run through VSTest, so the tests pass but no `.trx` files are produced. Consumers then get a neutral `Tests` check/comment with `0 tests`.

Observed in Eternet/Eternet.Payments.RedLink#115.

## Verification
- Reproduced in Payments.RedLink CI logs: tests passed, publisher warned `Could not find any files for **/TestResults/**/*.trx`.
- Verified locally in Payments.RedLink that `dotnet test ... --results-directory TestResults --logger trx` emits two `.trx` files and reports 67 passing tests.